### PR TITLE
Update manifest.json

### DIFF
--- a/export/manifest.json
+++ b/export/manifest.json
@@ -76,7 +76,7 @@
     },
     {
       "projectID": 1055882,
-      "fileID": 5525336,
+      "fileID": 6008005,
       "required": true
     },
     {
@@ -496,7 +496,7 @@
     },
     {
       "projectID": 990148,
-      "fileID": 5678256,
+      "fileID": 6000766,
       "required": true
     },
     {


### PR DESCRIPTION
Updated fileID references to:  
- [CIT for Roguelike Dungeons](https://www.curseforge.com/minecraft/texture-packs/rld-cit/files/6000766)  This fixes some Trading cards not showing their texture because Dregora is using 2021's RLD config files. Also makes the cards and paintings look bigger for enhanced visual pleasure.  
- [CIT for Doomlike Dungeons](https://www.curseforge.com/minecraft/texture-packs/dld-cit/files/6008005)  This fixes the enchantment-conditional CIT for the Clean Slicer. I hope this was not the reason why some people had their game crashed when the game tried to render the Clean Slicer, but if it was, this should fix that.