### PR TITLE
Fantastic Lib 069+ Set Bonus Config

### DIFF
--- a/export/overrides/config/setbonus/1.12.2.009+.cfg
+++ b/export/overrides/config/setbonus/1.12.2.009+.cfg
@@ -63,11 +63,11 @@ general {
         # WirtsLeggings, diamond_leggings > display:Name = "Wirt's Leggings" & ench: = minecraft:protection ; lvl:4s
         #  
         S:"1. Equipment" <
-            LHelm, leather_helmet > Quality:Name = "quality.masterful.name"
-            LChest, leather_chestplate > Quality:Name = "quality.masterful.name"
-            LLegs, leather_leggings > Quality:Name = "quality.masterful.name"
-            LSkirt, variedcommodities:leather_skirt > Quality:Name = "quality.masterful.name"
-            LBoots, leather_boots > Quality:Name = "quality.masterful.name"
+            LHelm, leather_helmet > Quality/Name = "quality.masterful.name"
+            LChest, leather_chestplate > Quality/Name = "quality.masterful.name"
+            LLegs, leather_leggings > Quality/Name = "quality.masterful.name"
+            LSkirt, variedcommodities:leather_skirt > Quality/Name = "quality.masterful.name"
+            LBoots, leather_boots > Quality/Name = "quality.masterful.name"
             NHelm, aquaculture:neptunium_helmet
             NChest, aquaculture:neptunium_chestplate
             NLegs, aquaculture:neptunium_leggings
@@ -152,10 +152,10 @@ general {
             GolemChest, forgottenitems:golem_chestplate
             GolemLegs, forgottenitems:golem_leggings
             GolemBoots, forgottenitems:golem_boots
-            GolemHelmM, forgottenitems:golem_helmet > Quality:Name = "quality.masterful.name"
-            GolemChestM, forgottenitems:golem_chestplate > Quality:Name = "quality.masterful.name"
-            GolemLegsM, forgottenitems:golem_leggings > Quality:Name = "quality.masterful.name"
-            GolemBootsM, forgottenitems:golem_boots > Quality:Name = "quality.masterful.name"
+            GolemHelmM, forgottenitems:golem_helmet > Quality/Name = "quality.masterful.name"
+            GolemChestM, forgottenitems:golem_chestplate > Quality/Name = "quality.masterful.name"
+            GolemLegsM, forgottenitems:golem_leggings > Quality/Name = "quality.masterful.name"
+            GolemBootsM, forgottenitems:golem_boots > Quality/Name = "quality.masterful.name"
             DMyrmexHelm, iceandfire:myrmex_desert_helmet
             DMyrmexChest, iceandfire:myrmex_desert_chestplate
             DMyrmexLegs, iceandfire:myrmex_desert_leggings


### PR DESCRIPTION
Fantastic Lib update changed how the Set Bonus config is parsed for nested nbt.

New syntax uses "/" instead of ":"

https://github.com/Laike-Endaril/Fantastic-Lib/commit/7ee448c1ffb23e32e0f2c0f37eb0feeec8b26e23

https://www.curseforge.com/minecraft/mc-mods/fantastic-lib/files/6699913


https://github.com/user-attachments/assets/a6013a44-57a6-4c03-a90d-b0c7a7433f42

