### PR TITLE
[Dregora] Fantastic Lib 069+ Set Bonus Config

### DIFF
--- a/export/overrides/config/setbonus/1.12.2.009+.cfg
+++ b/export/overrides/config/setbonus/1.12.2.009+.cfg
@@ -26,10 +26,10 @@ general {
         # WirtsLeggings, diamond_leggings > display:Name = "Wirt's Leggings" & ench: = minecraft:protection ; lvl:4s
         #  
         S:"1. Equipment" <
-            LHelm, leather_helmet > Quality:Name = "quality.masterful.name"
-            LChest, leather_chestplate > Quality:Name = "quality.masterful.name"
-            LLegs, leather_leggings > Quality:Name = "quality.masterful.name"
-            LBoots, leather_boots > Quality:Name = "quality.masterful.name"
+            LHelm, leather_helmet > Quality/Name = "quality.masterful.name"
+            LChest, leather_chestplate > Quality/Name = "quality.masterful.name"
+            LLegs, leather_leggings > Quality/Name = "quality.masterful.name"
+            LBoots, leather_boots > Quality/Name = "quality.masterful.name"
             NHelm, aquaculture:neptunium_helmet
             NChest, aquaculture:neptunium_chestplate
             NLegs, aquaculture:neptunium_leggings
@@ -110,10 +110,10 @@ general {
             GolemChest, forgottenitems:golem_chestplate
             GolemLegs, forgottenitems:golem_leggings
             GolemBoots, forgottenitems:golem_boots
-            GolemHelmM, forgottenitems:golem_helmet > Quality:Name = "quality.masterful.name"
-            GolemChestM, forgottenitems:golem_chestplate > Quality:Name = "quality.masterful.name"
-            GolemLegsM, forgottenitems:golem_leggings > Quality:Name = "quality.masterful.name"
-            GolemBootsM, forgottenitems:golem_boots > Quality:Name = "quality.masterful.name"
+            GolemHelmM, forgottenitems:golem_helmet > Quality/Name = "quality.masterful.name"
+            GolemChestM, forgottenitems:golem_chestplate > Quality/Name = "quality.masterful.name"
+            GolemLegsM, forgottenitems:golem_leggings > Quality/Name = "quality.masterful.name"
+            GolemBootsM, forgottenitems:golem_boots > Quality/Name = "quality.masterful.name"
             DMyrmexHelm, iceandfire:myrmex_desert_helmet
             DMyrmexChest, iceandfire:myrmex_desert_chestplate
             DMyrmexLegs, iceandfire:myrmex_desert_leggings
@@ -430,7 +430,7 @@ general {
             SGBonus2, potioncore:magic_shield.2.205
             GBonusTool, haste.1.205
             SGBonusTool, haste.2.205
-            SBonus2, potioncore:cure.0.205
+            SBonus2, potioncore:cure.255
             UBonus, strength.1.205
             UBonus2, lycanitesmobs:immunization.1.205
             GolemB1, lycanitesmobs:repulsion.1.205


### PR DESCRIPTION
[Fixed Cure+Wine according to Laike's instructions](https://github.com/fonnymunkey/RLCraft-Dregora-Edition/pull/132) + Laike's instructions for cure (Amplifier 255 + Infinite duration)

https://discord.com/channels/199155955206717440/643558657136787459/1369547058632982548

> Laike Endaril — 5/7/2025 12:31 AM
@cdstk_AIt Hey, I took a quick look at that potion extension issue
The new version will still remove the potion effect when the set bonus is lost so long as the current duration of the potion effect is less than the duration the set would apply
So if you set it to infinite duration (the default) for the set bonus potion effect, then when the set is removed, it will ALWAYS remove the potion effect...unless the current version of the potion effect has a higher level instead
Going along with that, if a set bonus gives you infinite strength 1 (until removed), and you drink a strength 2 potion, it will work correctly
Ie. you will get strength 2 for the normal duration of the potion, and then when it wears off, you'll go back to infinite strength 1
This might not have been the case in older versions, which might be why you guys don't have them set to infinite in the configs, but I'm not sure
In any case, if that sounds like it will work, the potion bonus definitions can just be trimmed down in the config from eg.
SBonus2, potioncore:cure.0.205
to
SBonus2, potioncore:cure
And for potion effects that need the amplifier defined (cure doesn't afaik), eg...
SGBonusTool, haste.2.205
to
SGBonusTool, haste.2
Let me know if that's a valid solution or not.  I'll look into the tooltips a bit
(For anyone reading this, this all applies to the LATEST version of Set Bonus, not the one currently in RLCraft or Dregora; you'd need to update if you decide to try this yourself) 
